### PR TITLE
Fine tune OAK-D 3D mapping example

### DIFF
--- a/python/oak/README.md
+++ b/python/oak/README.md
@@ -20,6 +20,8 @@ To install dependecies for all examples you can use: `pip install -r requirement
  * **Minimal example**. Prints 6-DoF poses as JSON text: [`python vio_jsonl.py`](vio_jsonl.py)
  * **Basic visualization**. Interactive 3D plot / draw in the air with the device: [`python vio_visu.py`](vio_visu.py)
  * **3D pen**. Draw in the air: cover the OAK-D color camera to activate the ink. [`python pen_3d.py`](pen_3d.py)
+ * **3D mapping**. Build and visualize 3D point cloud of the environment in real-time.
+    Also requires `open3d` to be installed, see [`mapping_visu.py`](mapping_visu.py) for details.
  * **Advanced Spatial AI example**. Spectacular AI VIO + Tiny YOLO object detection.
     See [`depthai_combination.py`](depthai_combination.py) for additional dependencies that also need to be installed.
  * **Mixed reality**. In less than 130 lines of Python, with the good old OpenGL functions like `glTranslatef` used for rendering.

--- a/python/oak/mapping_visu.py
+++ b/python/oak/mapping_visu.py
@@ -63,13 +63,13 @@ class CoordinateFrame:
         self.camToWorld = camToWorld
 
 class Open3DVisualization:
-    def __init__(self, voxelSize, cameraFollow, cameraSmooth, colorOnly):
+    def __init__(self, voxelSize, cameraManual, cameraSmooth, colorOnly):
         self.shouldClose = False
         self.pointClouds = {}
         self.cameraFrame = CoordinateFrame()
         self.vis = o3d.visualization.Visualizer()
         self.voxelSize = voxelSize
-        self.cameraFollow = cameraFollow
+        self.cameraFollow = not cameraManual
         self.cameraSmooth = cameraSmooth
         self.colorOnly = colorOnly
         self.prevPos = None
@@ -83,6 +83,7 @@ class Open3DVisualization:
         renderOption.point_size = 2
         renderOption.light_on = False
 
+        print("Close the window to stop mapping")
         while not self.shouldClose:
             self.shouldClose = not self.vis.poll_events()
             self.vis.update_renderer()
@@ -148,7 +149,7 @@ def parseArgs():
     p.add_argument("--dataFolder", help="Folder containing the recorded session for mapping")
     p.add_argument("--outputFolder", help="Folder where to save the captured point clouds")
     p.add_argument("--voxel", help="Voxel size (m) for downsampling point clouds")
-    p.add_argument("--follow", help="Make camera follow estimated pose; can make real-time mapping easier", action="store_true")
+    p.add_argument("--manual", help="Control Open3D camera manually", action="store_true")
     p.add_argument("--smooth", help="Apply some smoothing to 3rd person camera movement", action="store_true")
     p.add_argument("--color", help="Filter points without color", action="store_true")
     return p.parse_args()
@@ -158,7 +159,7 @@ if __name__ == '__main__':
     if args.outputFolder:
         os.makedirs(args.outputFolder)
     voxelSize = 0 if args.voxel is None else float(args.voxel)
-    visu3D = Open3DVisualization(voxelSize, args.follow, args.smooth, args.color)
+    visu3D = Open3DVisualization(voxelSize, args.manual, args.smooth, args.color)
 
     def onVioOutput(vioOutput):
         cameraPose = vioOutput.getCameraPose(0)


### PR DESCRIPTION
Makes camera follow by default, instructs the user to close the window to stop mapping, and adds the example to README.