### PR TITLE
AR visualization

### DIFF
--- a/python/oak/README.md
+++ b/python/oak/README.md
@@ -22,6 +22,7 @@ To install dependecies for all examples you can use: `pip install -r requirement
  * **3D pen**. Draw in the air: cover the OAK-D color camera to activate the ink. [`python pen_3d.py`](pen_3d.py)
  * **3D mapping**. Build and visualize 3D point cloud of the environment in real-time.
     Also requires `open3d` to be installed, see [`mapping_visu.py`](mapping_visu.py) for details.
+ * **3D mapping with Augmented Reality**. Show 3D mesh or point cloud on top of camera view, using OpenGL. [`mapping_ar.py`](mapping_ar.py)
  * **Advanced Spatial AI example**. Spectacular AI VIO + Tiny YOLO object detection.
     See [`depthai_combination.py`](depthai_combination.py) for additional dependencies that also need to be installed.
  * **Mixed reality**. In less than 130 lines of Python, with the good old OpenGL functions like `glTranslatef` used for rendering.
@@ -71,7 +72,7 @@ vio_pipeline.imuToCameraLeft = [
     [0, 0,-1, 0],
     [0, 0, 0, 1]
 ]
-``` 
+```
 SDK versions prior to v1.3.0 required this for all OAK-D series 2 models (OAK-D S2, OAK-D Pro etc.), but this is no longer the case in recent versions.
 
 ## License

--- a/python/oak/mapping_ar.py
+++ b/python/oak/mapping_ar.py
@@ -1,5 +1,14 @@
 """
 Draw Mapping API outputs on video to create an AR visualization.
+
+Requirements:
+    pip install pygame PyOpenGL
+And optionally to improve performance:
+    pip install PyOpenGL_accelerate
+
+* For OAK-D live use just plug in OAK-D and run `python3 mapping_ar.py`.
+* Press "x" to switch between the visualizations.
+* Press "q" to quit.
 """
 
 import os
@@ -8,8 +17,6 @@ import time
 import numpy as np
 
 from OpenGL.GL import * # all prefixed with gl so OK to import *
-# OpenGL.ERROR_CHECKING = False
-# OpenGL.ERROR_LOGGING = False
 
 os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = "hide"
 import pygame
@@ -100,10 +107,6 @@ def oakdLoop(args, state, device, vioSession):
 
 def main(args):
     configInternal = {
-        # "delayFrames": 0,
-        # "noWaitingForResults": "true",
-        # "maxSlamResultQueueSize": "2",
-
         "computeStereoPointCloud": "true",
         "pointCloudNormalsEnabled": "true",
         "computeDenseStereoDepth": "true",
@@ -124,8 +127,7 @@ def main(args):
             if not frame.image: continue
             if not frame.index == CAMERA_IND: continue
             img = frame.image.toArray()
-            # Flip the image upside down for OpenGL
-            img = np.ascontiguousarray(np.flipud(img))
+            img = np.ascontiguousarray(np.flipud(img)) # Flip the image upside down for OpenGL.
             width = img.shape[1]
             height = img.shape[0]
             cameraPose = vioOutput.getCameraPose(CAMERA_IND)
@@ -157,7 +159,7 @@ def parseArgs():
     p.add_argument("--dataFolder", help="Instead of running live mapping session, replay session from this folder")
     p.add_argument('--ir_dot_brightness', help='OAK-D Pro (W) IR laser projector brightness (mA), 0 - 1200', type=float, default=0)
     p.add_argument("--useRectification", help="--dataFolder option can also be used with some non-OAK-D recordings, but this parameter must be set if the videos inputs are not rectified.", action="store_true")
-    p.add_argument("--pointCloud", help="Show point cloud instead of mesh.", action="store_true")
+    p.add_argument("--pointCloud", help="Start in the point cloud mode.", action="store_true")
     p.add_argument("--resolution", help="Window resolution.", default="1920x1080")
     return p.parse_args()
 

--- a/python/oak/mapping_ar.py
+++ b/python/oak/mapping_ar.py
@@ -39,7 +39,8 @@ def main(args):
 
     class State:
         shouldQuit = False
-        lastMappingOutput = None
+        currentMapperOutput = None
+        lastMapperOutput = None
         displayInitialized = False
         pointCloudMode = args.pointCloud
         targetResolution = [int(s) for s in args.resolution.split("x")]
@@ -84,22 +85,25 @@ def main(args):
             glPixelZoom(state.scale, state.scale);
             glDrawPixels(width, height, GL_RGB, GL_UNSIGNED_BYTE, img.data)
 
-            if state.lastMappingOutput:
+            if state.currentMapperOutput:
                 if state.pointCloudMode:
                     if state.pointCloudRenderer:
-                        state.pointCloudRenderer.setPointCloud(state.lastMappingOutput)
+                        if state.currentMapperOutput is not state.lastMapperOutput:
+                            state.pointCloudRenderer.setPointCloud(state.currentMapperOutput)
                         state.pointCloudRenderer.setPose(cameraPose)
                         state.pointCloudRenderer.render()
                 else:
                     if state.meshRenderer:
-                        state.meshRenderer.setMesh(state.lastMappingOutput.mesh)
+                        if state.currentMapperOutput is not state.lastMapperOutput:
+                            state.meshRenderer.setMesh(state.currentMapperOutput.mesh)
                         state.meshRenderer.setPose(cameraPose)
                         state.meshRenderer.render()
+                state.lastMapperOutput = state.currentMapperOutput
             pygame.display.flip()
 
     def onMappingOutput(mapperOutput):
         nonlocal state
-        state.lastMappingOutput = mapperOutput
+        state.currentMapperOutput = mapperOutput
 
     if args.dataFolder:
         replay = spectacularAI.Replay(args.dataFolder, onMappingOutput, configuration=configInternal)

--- a/python/oak/mapping_ar.py
+++ b/python/oak/mapping_ar.py
@@ -42,6 +42,8 @@ def main(args):
         lastMappingOutput = None
         displayInitialized = False
         pointCloudMode = args.pointCloud
+        targetResolution = [int(s) for s in args.resolution.split("x")]
+        scale = None
         # Must be initialized after pygame.
         meshRenderer = None
         pointCloudRenderer = None
@@ -64,7 +66,11 @@ def main(args):
 
             if not state.displayInitialized:
                 state.displayInitialized = True
-                init_display(width, height)
+                targetWidth = state.targetResolution[0]
+                targetHeight = state.targetResolution[1]
+                state.scale = min(targetWidth / width, targetHeight / height)
+                adjustedResolution = [int(state.scale * width), int(state.scale * height)]
+                init_display(adjustedResolution[0], adjustedResolution[1])
                 state.meshRenderer = MeshRenderer()
                 state.pointCloudRenderer = PointCloudRenderer()
 
@@ -75,7 +81,9 @@ def main(args):
                     if event.key == pygame.K_x: state.pointCloudMode = not state.pointCloudMode
                 if state.shouldQuit: return
 
+            glPixelZoom(state.scale, state.scale);
             glDrawPixels(width, height, GL_RGB, GL_UNSIGNED_BYTE, img.data)
+
             if state.lastMappingOutput:
                 if state.pointCloudMode:
                     if state.pointCloudRenderer:
@@ -118,6 +126,7 @@ def parseArgs():
     p.add_argument('--ir_dot_brightness', help='OAK-D Pro (W) IR laser projector brightness (mA), 0 - 1200', type=float, default=0)
     p.add_argument("--useRectification", help="--dataFolder option can also be used with some non-OAK-D recordings, but this parameter must be set if the videos inputs are not rectified.", action="store_true")
     p.add_argument("--pointCloud", help="Show point cloud instead of mesh.", action="store_true")
+    p.add_argument("--resolution", help="Window resolution.", default="1920x1080")
     return p.parse_args()
 
 if __name__ == '__main__':

--- a/python/oak/mapping_ar.py
+++ b/python/oak/mapping_ar.py
@@ -1,0 +1,163 @@
+"""
+Draw Mapping API outputs on video to create an AR visualization.
+"""
+
+import os
+import time
+
+import numpy as np
+
+from OpenGL.GL import * # all prefixed with gl so OK to import *
+# OpenGL.ERROR_CHECKING = False
+# OpenGL.ERROR_LOGGING = False
+
+os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = "hide"
+import pygame
+
+import spectacularAI
+import depthai
+
+from mixed_reality import init_display, make_pipelines
+
+POINT_CLOUD_STRIDE = 2
+KEYFRAME_GROUP_SIZE = 2
+
+def drawMesh(currentCameraPose, mapperOutput):
+    if mapperOutput.mesh is None:
+        print("No mesh to draw.")
+        return
+
+    glEnable(GL_DEPTH_TEST);
+    glDepthMask(GL_TRUE);
+    glClear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
+    # glEnable(GL_BLEND);
+    # glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+    # TODO Draw
+
+    # glDisable(GL_BLEND);
+    glDisable(GL_DEPTH_TEST);
+    glDepthMask(GL_FALSE);
+    print("ok")
+
+def drawPointCloud(currentCameraPose, mapperOutput):
+    glLoadIdentity()
+    near, far = 0.01, 100.0 # clip
+    glMultMatrixd(currentCameraPose.camera.getProjectionMatrixOpenGL(near, far).transpose())
+    glMultMatrixd(currentCameraPose.getWorldToCameraMatrix().transpose())
+    glPointSize(3)
+    glColor3f(1, 0, 0)
+
+    keyFrameIds = []
+    for keyFrameId in mapperOutput.map.keyFrames:
+        keyFrameIds.append(keyFrameId)
+    keyFrameIds.sort(reverse=True)
+
+    for i, keyFrameId in enumerate(keyFrameIds):
+        if i >= KEYFRAME_GROUP_SIZE: return
+        keyFrame = mapperOutput.map.keyFrames[keyFrameId]
+        cameraPose = keyFrame.frameSet.primaryFrame.cameraPose
+
+        glPushMatrix();
+        glMultMatrixd(cameraPose.getCameraToWorldMatrix().transpose())
+        if keyFrame.pointCloud:
+            # TODO Use array-based geometry, per-vertex operations are very slow in PyOpenGL.
+            glBegin(GL_POINTS)
+            for i, p in enumerate(keyFrame.pointCloud.getPositionData()):
+                if i % POINT_CLOUD_STRIDE != 0: continue
+                glVertex3fv(p)
+            glEnd()
+        glPopMatrix();
+
+def main(args):
+    configInternal = {
+        # "delayFrames": 0,
+        # "noWaitingForResults": "true",
+        # "maxSlamResultQueueSize": "2",
+
+        "computeStereoPointCloud": "true",
+        "pointCloudNormalsEnabled": "true",
+        "computeDenseStereoDepth": "true",
+        "recEnabled": "true",
+    }
+    if args.dataFolder and args.useRectification:
+        configInternal["useRectification"] = "true"
+    else:
+        configInternal["alreadyRectified"] = "true"
+
+    shouldQuit = False
+    lastMappingOutput = None
+    displayInitialized = False
+    pointCloudMode = args.pointCloud
+
+    def onVioOutput(vioOutput, frameSet):
+        nonlocal lastMappingOutput
+        nonlocal displayInitialized
+        nonlocal pointCloudMode
+        nonlocal shouldQuit
+
+        cameraPose = vioOutput.getCameraPose(0)
+        camToWorld = cameraPose.getCameraToWorldMatrix()
+        for frame in frameSet:
+            if not frame.image: continue
+            if not frame.index == 0: continue # NOTE "primary frame"
+
+            img = frame.image.toArray()
+            # Flip the image upside down for OpenGL
+            img = np.ascontiguousarray(np.flipud(img))
+            width = img.shape[1]
+            height = img.shape[0]
+
+            if not displayInitialized:
+                displayInitialized = True
+                init_display(width, height)
+
+            shouldQuit = False
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT: shouldQuit = True
+                elif event.type == pygame.KEYDOWN:
+                    if event.key == pygame.K_q: shouldQuit = True
+                    if event.key == pygame.K_x: pointCloudMode = not pointCloudMode
+                if shouldQuit: return
+
+            glDrawPixels(width, height, GL_RGB, GL_UNSIGNED_BYTE, img.data)
+            if lastMappingOutput:
+                if pointCloudMode:
+                    drawPointCloud(cameraPose, lastMappingOutput)
+                else:
+                    drawMesh(cameraPose, lastMappingOutput)
+            pygame.display.flip()
+
+    def onMappingOutput(mapperOutput):
+        nonlocal lastMappingOutput
+        lastMappingOutput = mapperOutput
+
+    if args.dataFolder:
+        replay = spectacularAI.Replay(args.dataFolder, onMappingOutput, configuration=configInternal)
+        replay.setExtendedOutputCallback(onVioOutput)
+        replay.startReplay()
+        while not shouldQuit:
+            time.sleep(0.05)
+        replay.close()
+        pygame.quit()
+    else:
+        def captureLoop():
+            pipeline, vio_pipeline = make_pipelines(None, configInternal, onMappingOutput)
+            with depthai.Device(pipeline) as device, \
+                vio_pipeline.startSession(device) as vio_session:
+                if args.ir_dot_brightness > 0:
+                    device.setIrLaserDotProjectorBrightness(args.ir_dot_brightness)
+                # TODO Not implemented.
+
+def parseArgs():
+    import argparse
+    p = argparse.ArgumentParser(__doc__)
+    p.add_argument("--dataFolder", help="Instead of running live mapping session, replay session from this folder")
+    p.add_argument("--use_rgb", help="Use OAK-D RGB camera", action="store_true")
+    p.add_argument('--ir_dot_brightness', help='OAK-D Pro (W) IR laser projector brightness (mA), 0 - 1200', type=float, default=0)
+    p.add_argument("--useRectification", help="--dataFolder option can also be used with some non-OAK-D recordings, but this parameter must be set if the videos inputs are not rectified.", action="store_true")
+    p.add_argument("--pointCloud", help="Show point cloud instead of mesh.", action="store_true")
+    return p.parse_args()
+
+if __name__ == '__main__':
+    main(parseArgs())

--- a/python/oak/mapping_ar.py
+++ b/python/oak/mapping_ar.py
@@ -21,6 +21,83 @@ from mixed_reality import init_display, make_pipelines
 from mapping_ar_renderers.mesh import MeshRenderer
 from mapping_ar_renderers.point_cloud import PointCloudRenderer
 
+CAMERA_IND = 0
+
+class State:
+    shouldQuit = False
+    currentMapperOutput = None
+    lastMapperOutput = None
+    displayInitialized = False
+    pointCloudMode = None
+    targetResolution = None
+    scale = None
+    # Must be initialized after pygame.
+    meshRenderer = None
+    pointCloudRenderer = None
+
+def handleVioOutput(state, cameraPose, img, width, height):
+    if not state.displayInitialized:
+        state.displayInitialized = True
+        targetWidth = state.targetResolution[0]
+        targetHeight = state.targetResolution[1]
+        state.scale = min(targetWidth / width, targetHeight / height)
+        adjustedResolution = [int(state.scale * width), int(state.scale * height)]
+        init_display(adjustedResolution[0], adjustedResolution[1])
+        state.meshRenderer = MeshRenderer()
+        state.pointCloudRenderer = PointCloudRenderer()
+
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT: state.shouldQuit = True
+        elif event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_q: state.shouldQuit = True
+            if event.key == pygame.K_x: state.pointCloudMode = not state.pointCloudMode
+        if state.shouldQuit: return
+
+    glPixelZoom(state.scale, state.scale);
+    glDrawPixels(width, height, GL_RGB, GL_UNSIGNED_BYTE, img.data)
+
+    if state.currentMapperOutput:
+        if state.pointCloudMode:
+            if state.pointCloudRenderer:
+                if state.currentMapperOutput is not state.lastMapperOutput:
+                    state.pointCloudRenderer.setPointCloud(state.currentMapperOutput)
+                state.pointCloudRenderer.setPose(cameraPose)
+                state.pointCloudRenderer.render()
+        else:
+            if state.meshRenderer:
+                if state.currentMapperOutput is not state.lastMapperOutput:
+                    state.meshRenderer.setMesh(state.currentMapperOutput.mesh)
+                state.meshRenderer.setPose(cameraPose)
+                state.meshRenderer.render()
+        state.lastMapperOutput = state.currentMapperOutput
+    pygame.display.flip()
+
+def oakdLoop(args, state, device, vioSession):
+    img_queue = device.getOutputQueue(name="cam_out", maxSize=4, blocking=False)
+    # Buffer for frames: show together with the corresponding VIO output
+    frames = {}
+    frame_number = 1
+
+    while True:
+        if img_queue.has():
+            img = img_queue.get()
+            img_time = img.getTimestamp().total_seconds()
+            frames[frame_number] = img
+            vioSession.addTrigger(img_time, frame_number)
+            frame_number += 1
+        elif vioSession.hasOutput():
+            vioOutput = vioSession.getOutput()
+            if vioOutput.tag > 0:
+                img = frames.get(vioOutput.tag)
+                cameraPose = vioSession.getRgbCameraPose(vioOutput)
+                handleVioOutput(state, cameraPose, img.getRaw().data, img.getWidth(), img.getHeight())
+                # Discard old tags.
+                frames = { tag: v for tag, v in frames.items() if tag > vioOutput.tag }
+        else:
+            pygame.time.wait(1)
+        if state.shouldQuit:
+            return
+
 def main(args):
     configInternal = {
         # "delayFrames": 0,
@@ -37,69 +114,22 @@ def main(args):
     else:
         configInternal["alreadyRectified"] = "true"
 
-    class State:
-        shouldQuit = False
-        currentMapperOutput = None
-        lastMapperOutput = None
-        displayInitialized = False
-        pointCloudMode = args.pointCloud
-        targetResolution = [int(s) for s in args.resolution.split("x")]
-        scale = None
-        # Must be initialized after pygame.
-        meshRenderer = None
-        pointCloudRenderer = None
     state = State()
+    state.pointCloudMode = args.pointCloud
+    state.targetResolution = [int(s) for s in args.resolution.split("x")]
 
-    def onVioOutput(vioOutput, frameSet):
+    def replayOnVioOutput(vioOutput, frameSet):
         nonlocal state
-
-        cameraPose = vioOutput.getCameraPose(0)
-        camToWorld = cameraPose.getCameraToWorldMatrix()
         for frame in frameSet:
             if not frame.image: continue
-            if not frame.index == 0: continue # NOTE "primary frame"
-
+            if not frame.index == CAMERA_IND: continue
             img = frame.image.toArray()
             # Flip the image upside down for OpenGL
             img = np.ascontiguousarray(np.flipud(img))
             width = img.shape[1]
             height = img.shape[0]
-
-            if not state.displayInitialized:
-                state.displayInitialized = True
-                targetWidth = state.targetResolution[0]
-                targetHeight = state.targetResolution[1]
-                state.scale = min(targetWidth / width, targetHeight / height)
-                adjustedResolution = [int(state.scale * width), int(state.scale * height)]
-                init_display(adjustedResolution[0], adjustedResolution[1])
-                state.meshRenderer = MeshRenderer()
-                state.pointCloudRenderer = PointCloudRenderer()
-
-            for event in pygame.event.get():
-                if event.type == pygame.QUIT: state.shouldQuit = True
-                elif event.type == pygame.KEYDOWN:
-                    if event.key == pygame.K_q: state.shouldQuit = True
-                    if event.key == pygame.K_x: state.pointCloudMode = not state.pointCloudMode
-                if state.shouldQuit: return
-
-            glPixelZoom(state.scale, state.scale);
-            glDrawPixels(width, height, GL_RGB, GL_UNSIGNED_BYTE, img.data)
-
-            if state.currentMapperOutput:
-                if state.pointCloudMode:
-                    if state.pointCloudRenderer:
-                        if state.currentMapperOutput is not state.lastMapperOutput:
-                            state.pointCloudRenderer.setPointCloud(state.currentMapperOutput)
-                        state.pointCloudRenderer.setPose(cameraPose)
-                        state.pointCloudRenderer.render()
-                else:
-                    if state.meshRenderer:
-                        if state.currentMapperOutput is not state.lastMapperOutput:
-                            state.meshRenderer.setMesh(state.currentMapperOutput.mesh)
-                        state.meshRenderer.setPose(cameraPose)
-                        state.meshRenderer.render()
-                state.lastMapperOutput = state.currentMapperOutput
-            pygame.display.flip()
+            cameraPose = vioOutput.getCameraPose(CAMERA_IND)
+            handleVioOutput(state, cameraPose, img, width, height)
 
     def onMappingOutput(mapperOutput):
         nonlocal state
@@ -107,26 +137,24 @@ def main(args):
 
     if args.dataFolder:
         replay = spectacularAI.Replay(args.dataFolder, onMappingOutput, configuration=configInternal)
-        replay.setExtendedOutputCallback(onVioOutput)
+        replay.setExtendedOutputCallback(replayOnVioOutput)
         replay.startReplay()
         while not state.shouldQuit:
             time.sleep(0.05)
         replay.close()
         pygame.quit()
     else:
-        def captureLoop():
-            pipeline, vio_pipeline = make_pipelines(None, configInternal, onMappingOutput)
-            with depthai.Device(pipeline) as device, \
-                vio_pipeline.startSession(device) as vio_session:
-                if args.ir_dot_brightness > 0:
-                    device.setIrLaserDotProjectorBrightness(args.ir_dot_brightness)
-                # TODO Not implemented.
+        pipeline, vio_pipeline = make_pipelines(None, configInternal, onMappingOutput)
+        with depthai.Device(pipeline) as device, \
+            vio_pipeline.startSession(device) as vioSession:
+            if args.ir_dot_brightness > 0:
+                device.setIrLaserDotProjectorBrightness(args.ir_dot_brightness)
+            oakdLoop(args, state, device, vioSession)
 
 def parseArgs():
     import argparse
     p = argparse.ArgumentParser(__doc__)
     p.add_argument("--dataFolder", help="Instead of running live mapping session, replay session from this folder")
-    p.add_argument("--use_rgb", help="Use OAK-D RGB camera", action="store_true")
     p.add_argument('--ir_dot_brightness', help='OAK-D Pro (W) IR laser projector brightness (mA), 0 - 1200', type=float, default=0)
     p.add_argument("--useRectification", help="--dataFolder option can also be used with some non-OAK-D recordings, but this parameter must be set if the videos inputs are not rectified.", action="store_true")
     p.add_argument("--pointCloud", help="Show point cloud instead of mesh.", action="store_true")

--- a/python/oak/mapping_ar_renderers/mesh.frag
+++ b/python/oak/mapping_ar_renderers/mesh.frag
@@ -1,0 +1,26 @@
+#version 150
+
+precision mediump float;
+varying vec3 v_Normal;
+varying vec3 v_TexCoord;
+varying vec3 v_Position;
+varying vec4 v_ScreenNdcHomog;
+
+void main() {
+    vec3 objColor = vec3(0.5) + v_Normal*0.5;
+    float distanceAlpha = exp(-abs(v_ScreenNdcHomog.w) / 400.0);
+    float meshAlpha = 0.6 * distanceAlpha;
+    float alpha = v_TexCoord.z * meshAlpha;
+    vec2 border = v_TexCoord.xy;
+
+    float maxBord = 0.015;
+    float gridAlpha = min(1.0, 2.0 * distanceAlpha);
+    float relBord = 1.0 - min(border.x, border.y) / maxBord;
+    if (relBord > 0.0) {
+        vec3 gridCol = vec3(0.0, 1.0, 1.0);
+        float gridAlpha = gridAlpha * sqrt(v_TexCoord.z);
+        objColor = objColor * (1.0 -  gridAlpha) + gridAlpha * gridCol;
+        alpha = gridAlpha + (1.0 - gridAlpha) * alpha;
+    }
+    gl_FragColor = vec4(objColor, alpha);
+}

--- a/python/oak/mapping_ar_renderers/mesh.py
+++ b/python/oak/mapping_ar_renderers/mesh.py
@@ -2,28 +2,9 @@ import pathlib
 
 import numpy as np
 
-from OpenGL.GL import * # all prefixed with gl so OK to import *
+from OpenGL.GL import *
 
-def loadShader(shaderType, shaderSource):
-    shader = glCreateShader(shaderType)
-    assert(shader)
-    glShaderSource(shader, shaderSource)
-    glCompileShader(shader)
-    result = glGetShaderiv(shader, GL_COMPILE_STATUS)
-    if not result: raise RuntimeError(glGetShaderInfoLog(shader))
-    return shader
-
-def createProgram(vertexSource, fragmentSource):
-    vertexShader = loadShader(GL_VERTEX_SHADER, vertexSource)
-    fragmentShader = loadShader(GL_FRAGMENT_SHADER, fragmentSource)
-    program = glCreateProgram()
-    assert(program)
-    glAttachShader(program, vertexShader)
-    glAttachShader(program, fragmentShader)
-    glLinkProgram(program)
-    result = glGetProgramiv(program, GL_LINK_STATUS)
-    if not result: raise RuntimeError(glGetProgramInfoLog(program))
-    return program
+from .util import *
 
 class MeshProgram:
     def __init__(self, program):

--- a/python/oak/mapping_ar_renderers/mesh.py
+++ b/python/oak/mapping_ar_renderers/mesh.py
@@ -1,0 +1,112 @@
+import pathlib
+
+import numpy as np
+
+from OpenGL.GL import * # all prefixed with gl so OK to import *
+
+def loadShader(shaderType, shaderSource):
+    shader = glCreateShader(shaderType)
+    assert(shader)
+    glShaderSource(shader, shaderSource)
+    glCompileShader(shader)
+    result = glGetShaderiv(shader, GL_COMPILE_STATUS)
+    if not result: raise RuntimeError(glGetShaderInfoLog(shader))
+    return shader
+
+def createProgram(vertexSource, fragmentSource):
+    vertexShader = loadShader(GL_VERTEX_SHADER, vertexSource)
+    fragmentShader = loadShader(GL_FRAGMENT_SHADER, fragmentSource)
+    program = glCreateProgram()
+    assert(program)
+    glAttachShader(program, vertexShader)
+    glAttachShader(program, fragmentShader)
+    glLinkProgram(program)
+    result = glGetProgramiv(program, GL_LINK_STATUS)
+    if not result: raise RuntimeError(glGetProgramInfoLog(program))
+    return program
+
+class MeshProgram:
+    def __init__(self, program):
+        assert(program)
+        self.program = program
+        self.attributeVertex = glGetAttribLocation(self.program, "a_Position")
+        self.attributeTexCoord = glGetAttribLocation(self.program, "a_TexCoord")
+        self.attributeNormal = glGetAttribLocation(self.program, "a_Normal")
+        self.uniformModelViewProjection = glGetUniformLocation(self.program, "u_ModelViewProjection")
+
+class MeshRenderer:
+    modelViewProjection = None
+    meshProgram = None
+
+    # 1d arrays of GLfloat.
+    vertexData = np.array([])
+    normalData = np.array([])
+    texCoordData = np.array([])
+
+    def __init__(self):
+        assetDir = pathlib.Path(__file__).resolve().parent
+        meshVert = (assetDir / "mesh.vert").read_text()
+        meshFrag = (assetDir / "mesh.frag").read_text()
+        self.meshProgram = MeshProgram(createProgram(meshVert, meshFrag))
+
+    def render(self):
+        if self.modelViewProjection is None: return
+        if self.vertexData.shape[0] == 0: return
+
+        glEnable(GL_BLEND)
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+
+        glUseProgram(self.meshProgram.program)
+        glUniformMatrix4fv(self.meshProgram.uniformModelViewProjection, 1, GL_FALSE, self.modelViewProjection.transpose())
+
+        coordsPerVertex = 3
+        glEnableVertexAttribArray(self.meshProgram.attributeVertex)
+        glVertexAttribPointer(self.meshProgram.attributeVertex, coordsPerVertex,
+            GL_FLOAT, GL_FALSE, 0, self.vertexData)
+
+        glEnableVertexAttribArray(self.meshProgram.attributeTexCoord)
+        coordsPerTex = 3
+        glVertexAttribPointer(self.meshProgram.attributeTexCoord, coordsPerTex, GL_FLOAT, GL_FALSE, 0, self.texCoordData)
+
+        glEnableVertexAttribArray(self.meshProgram.attributeNormal)
+        glVertexAttribPointer(self.meshProgram.attributeNormal, coordsPerVertex, GL_FLOAT, GL_FALSE, 0,
+                              self.normalData)
+
+        nVertices = self.vertexData.shape[0] // coordsPerVertex
+        glDrawArrays(GL_TRIANGLES, 0, nVertices)
+
+        glDisableVertexAttribArray(self.meshProgram.attributeNormal)
+        glDisableVertexAttribArray(self.meshProgram.attributeTexCoord)
+        glDisableVertexAttribArray(self.meshProgram.attributeVertex)
+        glUseProgram(0)
+
+        glDisable(GL_BLEND)
+
+    def setMesh(self, mesh):
+        if mesh is None: return
+        if not mesh.hasNormals(): return
+
+        vertexPositions = mesh.getPositionData()
+        vertexInds = mesh.getFaceVertices().flatten()
+        self.vertexData = vertexPositions[vertexInds, :].flatten()
+
+        normals = mesh.getNormalData()
+        normalInds = mesh.getFaceNormals().flatten()
+        self.normalData = normals[normalInds, :].flatten()
+
+        self.texCoordData = np.array([])
+        n = len(vertexInds) // 3
+        c = 1.0 # Could be used for uncertainty.
+        self.texCoordData = np.zeros(3 * len(vertexInds))
+        for i in range(n):
+            self.texCoordData[9 * i + 3] = 1
+            self.texCoordData[9 * i + 7] = 1
+            self.texCoordData[9 * i + 2] = c
+            self.texCoordData[9 * i + 5] = c
+            self.texCoordData[9 * i + 8] = c
+
+    def setPose(self, cameraPose):
+        near, far = 0.01, 100.0
+        projection = cameraPose.camera.getProjectionMatrixOpenGL(near, far)
+        modelView = cameraPose.getWorldToCameraMatrix()
+        self.modelViewProjection = projection @ modelView

--- a/python/oak/mapping_ar_renderers/mesh.py
+++ b/python/oak/mapping_ar_renderers/mesh.py
@@ -82,7 +82,7 @@ class MeshRenderer:
 
         self.texCoordData = np.array([])
         n = len(vertexInds) // 3
-        c = 1.0 # Could be used for uncertainty.
+        c = 1.0 # Could be used for controlling alpha.
         self.texCoordData = np.zeros(3 * len(vertexInds))
         for i in range(n):
             self.texCoordData[9 * i + 3] = 1

--- a/python/oak/mapping_ar_renderers/mesh.py
+++ b/python/oak/mapping_ar_renderers/mesh.py
@@ -34,6 +34,10 @@ class MeshRenderer:
         if self.modelViewProjection is None: return
         if self.vertexData.shape[0] == 0: return
 
+        glEnable(GL_DEPTH_TEST);
+        glDepthMask(GL_TRUE);
+        glClear(GL_DEPTH_BUFFER_BIT);
+
         glEnable(GL_BLEND)
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 
@@ -62,6 +66,7 @@ class MeshRenderer:
         glUseProgram(0)
 
         glDisable(GL_BLEND)
+        glDisable(GL_DEPTH_TEST);
 
     def setMesh(self, mesh):
         if mesh is None: return

--- a/python/oak/mapping_ar_renderers/mesh.vert
+++ b/python/oak/mapping_ar_renderers/mesh.vert
@@ -1,0 +1,18 @@
+#version 150
+
+uniform mat4 u_ModelViewProjection;
+attribute vec3 a_Position;
+attribute vec3 a_Normal;
+attribute vec3 a_TexCoord;
+varying vec3 v_Normal;
+varying vec3 v_TexCoord;
+varying vec3 v_Position;
+varying vec4 v_ScreenNdcHomog;
+
+void main() {
+    v_Normal = a_Normal;
+    v_TexCoord = a_TexCoord;
+    v_Position = a_Position.xyz;
+    v_ScreenNdcHomog = u_ModelViewProjection * vec4(a_Position.xyz, 1.0);
+    gl_Position = v_ScreenNdcHomog;
+}

--- a/python/oak/mapping_ar_renderers/point_cloud.frag
+++ b/python/oak/mapping_ar_renderers/point_cloud.frag
@@ -1,0 +1,7 @@
+#version 150
+
+precision mediump float;
+
+void main() {
+    gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+}

--- a/python/oak/mapping_ar_renderers/point_cloud.frag
+++ b/python/oak/mapping_ar_renderers/point_cloud.frag
@@ -1,7 +1,9 @@
 #version 150
 
 precision mediump float;
+varying vec4 v_Position;
 
 void main() {
-    gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+    float a = 1.0 / max(1.5 * v_Position.z, 1.0);
+    gl_FragColor = vec4(1 - a, a, 0.2, 1.0);
 }

--- a/python/oak/mapping_ar_renderers/point_cloud.py
+++ b/python/oak/mapping_ar_renderers/point_cloud.py
@@ -1,0 +1,85 @@
+import pathlib
+
+import numpy as np
+
+from OpenGL.GL import *
+
+from .util import *
+
+POINT_CLOUD_STRIDE = 2
+
+class PointCloudProgram:
+    def __init__(self, program):
+        assert(program)
+        self.program = program
+        self.attributeVertex = glGetAttribLocation(self.program, "a_Position")
+        self.uniformModelViewProjection = glGetUniformLocation(self.program, "u_ModelViewProjection")
+
+class PointCloudRenderer:
+    modelViewProjection = None
+    pcProgram = None
+
+    # 1d arrays of GLfloat.
+    vertexData = np.array([])
+
+    def __init__(self):
+        assetDir = pathlib.Path(__file__).resolve().parent
+        pcVert = (assetDir / "point_cloud.vert").read_text()
+        pcFrag = (assetDir / "point_cloud.frag").read_text()
+        self.pcProgram = PointCloudProgram(createProgram(pcVert, pcFrag))
+
+    def render(self):
+        if self.modelViewProjection is None: return
+        if self.vertexData.shape[0] == 0: return
+
+        glEnable(GL_BLEND)
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+        glEnable(GL_PROGRAM_POINT_SIZE)
+
+        glUseProgram(self.pcProgram.program)
+        glUniformMatrix4fv(self.pcProgram.uniformModelViewProjection, 1, GL_FALSE, self.modelViewProjection.transpose())
+
+        coordsPerVertex = 3
+        glEnableVertexAttribArray(self.pcProgram.attributeVertex)
+        glVertexAttribPointer(self.pcProgram.attributeVertex, coordsPerVertex,
+            GL_FLOAT, GL_FALSE, 0, self.vertexData)
+
+        nVertices = self.vertexData.shape[0] // coordsPerVertex
+        glDrawArrays(GL_POINTS, 0, nVertices)
+
+        glDisableVertexAttribArray(self.pcProgram.attributeVertex)
+        glUseProgram(0)
+
+        glDisable(GL_PROGRAM_POINT_SIZE)
+        glDisable(GL_BLEND)
+
+    def setPointCloud(self, mapperOutput):
+        keyFrameIds = []
+        for keyFrameId in mapperOutput.map.keyFrames:
+            keyFrameIds.append(keyFrameId)
+        keyFrameIds.sort(reverse=True)
+
+        def transform(M, p):
+            return M[:3, :3] @ p + M[:3, 3]
+
+        for i, keyFrameId in enumerate(keyFrameIds):
+            # TODO This loop needs to append rather than replace vertexData if this
+            # size is increased beyond 1.
+            KEYFRAME_GROUP_SIZE = 1
+            if i >= KEYFRAME_GROUP_SIZE: return
+
+            keyFrame = mapperOutput.map.keyFrames[keyFrameId]
+            if not keyFrame.pointCloud: continue
+            cameraPose = keyFrame.frameSet.primaryFrame.cameraPose
+            cToW = cameraPose.getCameraToWorldMatrix()
+            points = keyFrame.pointCloud.getPositionData()
+            n = points.shape[0]
+            self.vertexData = np.zeros(3 * n)
+            for i in range(n):
+                self.vertexData[(3 * i):(3 * i + 3)] = transform(cToW, points[i, :])
+
+    def setPose(self, cameraPose):
+        near, far = 0.01, 100.0
+        projection = cameraPose.camera.getProjectionMatrixOpenGL(near, far)
+        modelView = cameraPose.getWorldToCameraMatrix()
+        self.modelViewProjection = projection @ modelView

--- a/python/oak/mapping_ar_renderers/point_cloud.vert
+++ b/python/oak/mapping_ar_renderers/point_cloud.vert
@@ -2,8 +2,10 @@
 
 uniform mat4 u_ModelViewProjection;
 attribute vec3 a_Position;
+varying vec4 v_Position;
 
 void main() {
-    gl_PointSize = 3.0;
-    gl_Position = u_ModelViewProjection * vec4(a_Position.xyz, 1.0);
+    v_Position = u_ModelViewProjection * vec4(a_Position.xyz, 1.0);
+    gl_Position = v_Position;
+    gl_PointSize = 1.0 + 10.0 / v_Position.z;
 }

--- a/python/oak/mapping_ar_renderers/point_cloud.vert
+++ b/python/oak/mapping_ar_renderers/point_cloud.vert
@@ -7,5 +7,5 @@ varying vec4 v_Position;
 void main() {
     v_Position = u_ModelViewProjection * vec4(a_Position.xyz, 1.0);
     gl_Position = v_Position;
-    gl_PointSize = 1.0 + 10.0 / v_Position.z;
+    gl_PointSize = 1.0 + 7.0 / v_Position.z;
 }

--- a/python/oak/mapping_ar_renderers/point_cloud.vert
+++ b/python/oak/mapping_ar_renderers/point_cloud.vert
@@ -1,0 +1,9 @@
+#version 150
+
+uniform mat4 u_ModelViewProjection;
+attribute vec3 a_Position;
+
+void main() {
+    gl_PointSize = 3.0;
+    gl_Position = u_ModelViewProjection * vec4(a_Position.xyz, 1.0);
+}

--- a/python/oak/mapping_ar_renderers/util.py
+++ b/python/oak/mapping_ar_renderers/util.py
@@ -1,0 +1,22 @@
+from OpenGL.GL import *
+
+def loadShader(shaderType, shaderSource):
+    shader = glCreateShader(shaderType)
+    assert(shader)
+    glShaderSource(shader, shaderSource)
+    glCompileShader(shader)
+    result = glGetShaderiv(shader, GL_COMPILE_STATUS)
+    if not result: raise RuntimeError(glGetShaderInfoLog(shader))
+    return shader
+
+def createProgram(vertexSource, fragmentSource):
+    vertexShader = loadShader(GL_VERTEX_SHADER, vertexSource)
+    fragmentShader = loadShader(GL_FRAGMENT_SHADER, fragmentSource)
+    program = glCreateProgram()
+    assert(program)
+    glAttachShader(program, vertexShader)
+    glAttachShader(program, fragmentShader)
+    glLinkProgram(program)
+    result = glGetProgramiv(program, GL_LINK_STATUS)
+    if not result: raise RuntimeError(glGetProgramInfoLog(program))
+    return program

--- a/python/oak/mapping_visu.py
+++ b/python/oak/mapping_visu.py
@@ -182,12 +182,24 @@ def parseArgs():
     p.add_argument("--color", help="Filter points without color", action="store_true")
     p.add_argument("--use_rgb", help="Use OAK-D RGB camera", action="store_true")
     p.add_argument('--ir_dot_brightness', help='OAK-D Pro (W) IR laser projector brightness (mA), 0 - 1200', type=float, default=0)
+    p.add_argument("--useRectification", help="--dataFolder option can also be used with some non-OAK-D recordings, but this parameter must be set if the videos inputs are not rectified.", action="store_true")
     return p.parse_args()
 
 if __name__ == '__main__':
     args = parseArgs()
     if args.outputFolder:
         os.makedirs(args.outputFolder)
+
+    configInternal = {
+        "computeStereoPointCloud": "true",
+        "pointCloudNormalsEnabled": "true",
+        "computeDenseStereoDepth": "true",
+    }
+    if args.dataFolder and args.useRectification:
+        configInternal["useRectification"] = "true"
+    else:
+        configInternal["alreadyRectified"] = "true"
+
     voxelSize = 0 if args.voxel is None else float(args.voxel)
     visu3D = Open3DVisualization(voxelSize, args.manual, args.smooth, args.color)
 
@@ -221,7 +233,7 @@ if __name__ == '__main__':
 
     if args.dataFolder:
         print("Starting replay")
-        replay = spectacularAI.Replay(args.dataFolder, onMappingOutput)
+        replay = spectacularAI.Replay(args.dataFolder, onMappingOutput, configuration=configInternal)
         replay.setOutputCallback(onVioOutput)
         replay.startReplay()
         visu3D.run()
@@ -234,10 +246,7 @@ if __name__ == '__main__':
             if args.recordingFolder:
                 config.recordingFolder = args.recordingFolder
             config.useColor = args.use_rgb
-            config.internalParameters = {
-                "computeStereoPointCloud": "true",
-                "pointCloudNormalsEnabled": "true"
-            }
+            config.internalParameters = configInternal
             vioPipeline = spectacularAI.depthai.Pipeline(pipeline, config, onMappingOutput)
 
             with depthai.Device(pipeline) as device, \

--- a/python/oak/mapping_visu.py
+++ b/python/oak/mapping_visu.py
@@ -173,8 +173,8 @@ class Open3DVisualization:
 def parseArgs():
     import argparse
     p = argparse.ArgumentParser(__doc__)
-    p.add_argument("--dataFolder", help="Folder containing the recorded session for mapping")
-    p.add_argument("--recordingFolder", help="Folder for recording the input data for offline replay")
+    p.add_argument("--dataFolder", help="Instead of running live mapping session, replay session from this folder")
+    p.add_argument("--recordingFolder", help="Record live mapping session for replay")
     p.add_argument("--outputFolder", help="Folder where to save the captured point clouds")
     p.add_argument("--voxel", help="Voxel size (m) for downsampling point clouds")
     p.add_argument("--manual", help="Control Open3D camera manually", action="store_true")

--- a/python/oak/mixed_reality.py
+++ b/python/oak/mixed_reality.py
@@ -23,10 +23,10 @@ def parse_args():
 def make_pipelines(mapLoadPath=None, vioInternalParameters={}, onMappingOutput=None):
     pipeline = depthai.Pipeline()
     config = spectacularAI.depthai.Configuration()
+    config.internalParameters = vioInternalParameters
     if mapLoadPath is not None:
         config.mapLoadPath = mapLoadPath
         config.useSlam = True
-        config.internalParameters = vioInternalParameters
     vio_pipeline = spectacularAI.depthai.Pipeline(pipeline, config, onMappingOutput)
 
     # NOTE: this simple method of reading RGB data from the device does not

--- a/python/oak/mixed_reality.py
+++ b/python/oak/mixed_reality.py
@@ -20,13 +20,14 @@ def parse_args():
     p.add_argument('--objLoadPath', help="Load scene as .obj", default=None)
     return p.parse_args()
 
-def make_pipelines(args):
+def make_pipelines(mapLoadPath=None, vioInternalParameters={}, onMappingOutput=None):
     pipeline = depthai.Pipeline()
     config = spectacularAI.depthai.Configuration()
-    if args.mapLoadPath is not None:
-        config.mapLoadPath = args.mapLoadPath
+    if mapLoadPath is not None:
+        config.mapLoadPath = mapLoadPath
         config.useSlam = True
-    vio_pipeline = spectacularAI.depthai.Pipeline(pipeline, config)
+        config.internalParameters = vioInternalParameters
+    vio_pipeline = spectacularAI.depthai.Pipeline(pipeline, config, onMappingOutput)
 
     # NOTE: this simple method of reading RGB data from the device does not
     # scale to well to higher resolutions. Use YUV data with larger resolutions
@@ -172,7 +173,7 @@ def main_loop(args, device, vio_session):
 
 if __name__ == '__main__':
     args = parse_args()
-    pipeline, vio_pipeline = make_pipelines(args)
+    pipeline, vio_pipeline = make_pipelines(args.mapLoadPath)
     with depthai.Device(pipeline) as device, \
         vio_pipeline.startSession(device) as vio_session:
         main_loop(args, device, vio_session)


### PR DESCRIPTION
Also @kaatrasa

This PR adds example mesh and point cloud visualizations for the SDK Mapping API. It works live on OAK-D and with recorded sessions.

The example is invoked through `mapping_ar.py` which internally uses two separate classes in the `mapping_ar_renderers/` directory:
```
├── mapping_ar.py
└── mapping_ar_renderers
    ├── mesh.py
    ├── mesh.frag
    ├── mesh.vert
    ├── point_cloud.py
    ├── point_cloud.frag
    └── point_cloud.vert
```

The commits are probably best viewed together.

Requires SDK features not released yet, perhaps should not be merged before the next release.