### PR TITLE
Hide ffmpeg output in vio_record.py

### DIFF
--- a/python/oak/vio_record.py
+++ b/python/oak/vio_record.py
@@ -159,10 +159,16 @@ def main_loop(plotter=None):
         videoFileNames.append(grayVideoFile.name)
         grayVideoFile.close()
 
+
+    if os.name == 'nt':
+        ffmpegStdErrToNull = "2>NUL"
+    else:
+        ffmpegStdErrToNull = "2>/dev/null"
+
     for fn in videoFileNames:
         if not args.no_convert:
             withoutExt = fn.rpartition('.')[0]
-            ffmpegCommand = "ffmpeg -framerate 30 -y -i {} -avoid_negative_ts make_zero -c copy {}.mp4".format(fn, withoutExt)
+            ffmpegCommand = "ffmpeg -framerate 30 -y -i {} -avoid_negative_ts make_zero -c copy {}.mp4 {}".format(fn, withoutExt, ffmpegStdErrToNull)
 
             result = subprocess.run(ffmpegCommand, shell=True)
             if result.returncode == 0:

--- a/python/oak/vio_record.py
+++ b/python/oak/vio_record.py
@@ -159,7 +159,6 @@ def main_loop(plotter=None):
         videoFileNames.append(grayVideoFile.name)
         grayVideoFile.close()
 
-
     if os.name == 'nt':
         ffmpegStdErrToNull = "2>NUL"
     else:


### PR DESCRIPTION
or @oseiskar

Hides this message when closing the recording window:
```
ffmpeg version 2022-06-30-git-03b2ed9a50-essentials_build-www.gyan.dev Copyright (c) 2000-2022 the FFmpeg developers
  built with gcc 12.1.0 (Rev2, Built by MSYS2 project)
  configuration: --enable-gpl --enable-version3 --enable-static --disable-w32threads --disable-autodetect --enable-fontconfig --enable-iconv --enable-gnutls --enable-libxml2 --enable-gmp --enable-bzlib --enable-lzma --enable-zlib --enable-libsrt --enable-libssh --enable-libzmq --enable-avisynth --enable-sdl2 --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxvid --enable-libaom --enable-libopenjpeg --enable-libvpx --enable-mediafoundation --enable-libass --enable-libfreetype --enable-libfribidi --enable-libvidstab --enable-libvmaf --enable-libzimg --enable-amf --enable-cuda-llvm --enable-cuvid --enable-ffnvcodec --enable-nvdec --enable-nvenc --enable-d3d11va --enable-dxva2 --enable-libmfx --enable-libgme --enable-libopenmpt --enable-libopencore-amrwb --enable-libmp3lame --enable-libtheora --enable-libvo-amrwbenc --enable-libgsm --enable-libopencore-amrnb --enable-libopus --enable-libspeex --enable-libvorbis --enable-librubberband
  libavutil      57. 27.100 / 57. 27.100
  libavcodec     59. 34.100 / 59. 34.100
  libavformat    59. 25.100 / 59. 25.100
  libavdevice    59.  6.100 / 59.  6.100
  libavfilter     8. 41.100 /  8. 41.100
  libswscale      6.  6.100 /  6.  6.100
  libswresample   4.  6.100 /  4.  6.100
  libpostproc    56.  5.100 / 56.  5.100
[hevc @ 000001ceee85e300] Stream #0: not enough frames to estimate rate; consider increasing probesize
Input #0, hevc, from 'C:\Users\valtt\data\test\2/rgb_video.h265':
  Duration: N/A, bitrate: N/A
  Stream #0:0: Video: hevc (Main), yuv420p(tv, bt470bg), 1920x1080 [SAR 1:1 DAR 16:9], 30 fps, 30 tbr, 1200k tbn
Output #0, mp4, to 'C:\Users\valtt\data\test\2/rgb_video.mp4':
  Metadata:
    encoder         : Lavf59.25.100
  Stream #0:0: Video: hevc (Main) (hev1 / 0x31766568), yuv420p(tv, bt470bg), 1920x1080 [SAR 1:1 DAR 16:9], q=2-31, 30 fps, 30 tbr, 1200k tbn
Stream mapping:
  Stream #0:0 -> #0:0 (copy)
Press [q] to stop, [?] for help
[mp4 @ 000001ceee92ed00] Timestamps are unset in a packet for stream 0. This is deprecated and will stop working in the future. Fix your code to set the timestamps properly
[mp4 @ 000001ceee92ed00] pts has no value
[mp4 @ 000001ceee92ed00] pts has no valueB time=-00:00:00.09 bitrate=N/A speed=N/A
    Last message repeated 168 times
frame=  170 fps=0.0 q=-1.0 Lsize=    5957kB time=00:00:05.53 bitrate=8819.7kbits/s speed=32.8x
video:5954kB audio:0kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: 0.049318%
```