### PR TITLE
Remove deprecated processing-queue use

### DIFF
--- a/cpp/offline/vio_jsonl.cpp
+++ b/cpp/offline/vio_jsonl.cpp
@@ -29,7 +29,8 @@ int main(int argc, char *argv[]) {
     std::ostringstream config;
     // This option makes the data input wait for VIO to finish to avoid dropping frames.
     // It should not be used in real-time scenarios.
-    config << "processingQueueSize: 0\n";
+    config << "blockingReplay: True\n";
+
     config << input->getConfig();
     auto builder = spectacularAI::Vio::builder()
         .setConfigurationYAML(config.str())

--- a/cpp/replay/replay.cpp
+++ b/cpp/replay/replay.cpp
@@ -53,9 +53,6 @@ int main(int argc, char *argv[]) {
         // performance, so we concatenate our changes to it.
         configurationYaml << readFileToString(dataConfigurationYamlPath) << std::endl;
     }
-    // The `processingQueueSize` option makes the data input wait for VIO to finish to
-    // avoid dropping frames. It should not be used in real-time scenarios.
-    configurationYaml << "processingQueueSize: 0\n";
     configurationYaml << userConfigurationYaml;
 
     // The Replay API builder takes as input the main API builder as a way to share


### PR DESCRIPTION
I tested both the changed examples and got a good position trajectory and no messages about data being input too fast.