### PR TITLE
Undistort images in mixed_reality_replay.py

### DIFF
--- a/python/oak/mixed_reality_replay.py
+++ b/python/oak/mixed_reality_replay.py
@@ -84,7 +84,8 @@ def onOutput(output, frameSet):
             pygame.display.flip()
             break # Skip other frames
 
-replay = spectacularAI.Replay(args.dataFolder)
+configInternal = { "useRectification": "true" } # Undistort images for visualization (assumes undistorted pinhole model)
+replay = spectacularAI.Replay(args.dataFolder, configuration=configInternal)
 replay.setExtendedOutputCallback(onOutput)
 replay.startReplay()
 while not shouldQuit:


### PR DESCRIPTION
or @Bercon

Undistorts the background image. The AR objects use `Camera::getProjectionMatrixOpenGL()`, which matches to the undistorted image.