### PR TITLE
Undistort OAK-D rgb camera in AR examples

### DIFF
--- a/python/oak/mixed_reality_replay.py
+++ b/python/oak/mixed_reality_replay.py
@@ -4,7 +4,6 @@ Mixed reality example using PyOpenGL. Requirements:
     pip install pygame PyOpenGL PyOpenGL_accelerate
 
 """
-import depthai
 import spectacularAI
 import pygame
 import time


### PR DESCRIPTION
Currently, we render AR objects with undistorted pinhole model, but the background image is still distorted in live examples (`mixed_reality.py` & `mapping_ar.py`). Now the color image is undistorted on the OAKD device and then converted from YUV to RGB using `ImageManip` nodes. Seems to work on my OAK-D, but ideally we should test on OAK-D Pro W.