### PR TITLE
Fix C++ depthai plugin replay example

### DIFF
--- a/cpp/oak/CMakeLists.txt
+++ b/cpp/oak/CMakeLists.txt
@@ -12,7 +12,7 @@ if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 else()
   set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wl,--no-as-needed")
 endif()
 
 set(USE_OPENCV OFF CACHE STRING "Use OpenCV debug visualizations")

--- a/cpp/oak/vio_replay.cpp
+++ b/cpp/oak/vio_replay.cpp
@@ -7,7 +7,10 @@
 #endif
 
 int main(int argc, char** argv) {
-    if (argc < 2) return 1;
+    if (argc < 2) {
+        std::cout << "Usage: vio_jsonl path/to/recording" << std::endl;
+        return 1;
+    }
 
     std::string dataFolder = argv[1];
 


### PR DESCRIPTION
Without the option `-Wl,--no-as-needed` I get `./vio_jsonl: error while loading shared libraries: libdepthai-core.so: cannot open shared object file: No such file or directory`

> --no-as-needed: This is an option for the linker. By default, when linking a shared library, the linker will only link the library if there is an unsatisfied symbol in the object being linked. --no-as-needed disables this behavior, causing the linker to always link the specified libraries, regardless of whether there are any unsatisfied symbols.