### PR TITLE
Remove alreadyRectified flag from replay examples

### DIFF
--- a/python/oak/april_tag.py
+++ b/python/oak/april_tag.py
@@ -182,8 +182,6 @@ if __name__ == '__main__':
         }
         if args.useRectification:
             configInternal["useRectification"] = "true" # Undistort images for visualization (assumes undistorted pinhole model)
-        else:
-            configInternal["alreadyRectified"] = "true"
 
         replay = spectacularAI.Replay(args.dataFolder, onMappingOutput, configuration=configInternal)
         replay.setExtendedOutputCallback(replayOnVioOutput)

--- a/python/oak/mapping_ar.py
+++ b/python/oak/mapping_ar.py
@@ -185,8 +185,6 @@ def main(args):
         }
     if args.useRectification:
         configInternal["useRectification"] = "true"
-    else:
-        configInternal["alreadyRectified"] = "true"
     configInternal["stereoPointCloudMaxDepth"] = str(args.depth)
     configInternal["recMaxDistance"] = str(args.depth)
 

--- a/python/oak/mapping_ros.py
+++ b/python/oak/mapping_ros.py
@@ -168,8 +168,6 @@ if __name__ == '__main__':
     }
     if args.useRectification:
         configInternal["useRectification"] = "true"
-    else:
-        configInternal["alreadyRectified"] = "true"
 
     slam_node = SLAMNode()
 

--- a/python/oak/mapping_visu.py
+++ b/python/oak/mapping_visu.py
@@ -23,7 +23,7 @@ def parseArgs():
     p.add_argument("--useRgb", help="Use OAK-D RGB camera", action="store_true")
     p.add_argument('--irDotBrightness', help='OAK-D Pro (W) IR laser projector brightness (mA), 0 - 1200', type=float, default=0)
     p.add_argument('--noFeatureTracker', help='Disable on-device feature tracking and depth map', action="store_true")
-    p.add_argument("--useRectification", help="--dataFolder option can also be used with some non-OAK-D recordings, but this parameter must be set if the videos inputs are not rectified.", action="store_true")
+    p.add_argument("--useRectification", help="This parameter must be set if the stereo video inputs are not rectified", action="store_true")
     p.add_argument('--keyFrameCandidateInterval', type=int, help='Sets internal parameter keyframeCandidateEveryNthFrame')
     return p.parse_args()
 
@@ -35,10 +35,9 @@ if __name__ == '__main__':
         "pointCloudNormalsEnabled": "true",
         "computeDenseStereoDepth": "true",
     }
+
     if args.dataFolder and args.useRectification:
         configInternal["useRectification"] = "true"
-    else:
-        configInternal["alreadyRectified"] = "true"
 
     visArgs = VisualizerArgs()
     visArgs.resolution = args.resolution

--- a/python/oak/mixed_reality_replay.py
+++ b/python/oak/mixed_reality_replay.py
@@ -13,7 +13,7 @@ def parseArgs():
     import argparse
     p = argparse.ArgumentParser(__doc__)
     p.add_argument("dataFolder", help="Folder containing the recorded session for replay", default="data")
-    p.add_argument("--useRectification", help="This parameter must be set if the videos inputs are not rectified", action="store_true")
+    p.add_argument("--useRectification", help="This parameter must be set if the video inputs are not rectified", action="store_true")
     p.add_argument('--cameraInd', help="Which camera to use. Typically 0=left, 1=right, 2=auxiliary/RGB (OAK-D default)", type=int, default=2)
     p.add_argument("--mapLoadPath", help="SLAM map path", default=None)
     p.add_argument('--objLoadPath', help="Load scene as .obj", default=None)
@@ -29,8 +29,6 @@ if __name__ == '__main__':
     configInternal = {}
     if args.useRectification:
         configInternal["useRectification"] = "true" # Undistort images for visualization (assumes undistorted pinhole model)
-    else:
-        configInternal["alreadyRectified"] = "true"
 
     if args.mapLoadPath:
         configInternal["mapLoadPath"] = args.mapLoadPath

--- a/python/oak/ros2/spectacularai_depthai/ros2_node.py
+++ b/python/oak/ros2/spectacularai_depthai/ros2_node.py
@@ -108,8 +108,7 @@ class SpectacularAINode(Node):
         config.internalParameters = {
             "ffmpegVideoCodec": "libx264 -crf 15 -preset ultrafast",
             "computeStereoPointCloud": "true",
-            "computeDenseStereoDepthKeyFramesOnly": "true",
-            "alreadyRectified": "true"
+            "computeDenseStereoDepthKeyFramesOnly": "true"
         }
         config.useSlam = True
 


### PR DESCRIPTION
or @oseiskar

The `alreadyRectified` flag was meant mainly for OAK-D replay, but now it is automatically set by the OAK-D wrapper. However, the flag shouldn't be used when the frames are actually distorted, e.g. Orbbec & Azure Kinect.