### PR TITLE
Add relocalize-apriltags-example

### DIFF
--- a/python/oak/relocalize_apriltags.py
+++ b/python/oak/relocalize_apriltags.py
@@ -1,86 +1,76 @@
 import argparse
 import spectacularAI
-import cv2
 import time
 import threading
 import os
 from enum import Enum
 
 class State(Enum):
-    FindAprilTagTime = 1
-    FindRelocalizeTime = 2
-    FindAprilTagPose = 3
-    FindRelocalizePose = 4
+    FindRelocalizeTime = 1
+    FindAprilTagTime = 2
+    FindRelocalizePose = 3
 
-pairedFrameTime = None
 aprilTagFrameTime = None
 aprilTagFramePose = None
 relocalizedFrameTime = None
 relocalizedFramePose = None
 args = None
 aprilTagReplay1 = None
-aprilTagReplay2 = None
 relocalizeReplay1 = None
 relocalizeReplay2 = None
-state = None
-
-def onAprilTagExtendedOutput(output, frameSet):
-    global args, aprilTagFrameTime, aprilTagFramePose, aprilTagReplay1, aprilTagReplay2, pairedFrameTime, state
-    # print(output.status)
-    if not output.status == spectacularAI.TrackingStatus.TRACKING: return # not tracking yet
-
-    for frame in frameSet:
-        if not pairedFrameTime:
-            if not aprilTagFrameTime:
-                aprilTagFrameTime = output.pose.time
-                print("Tracking started with April Tag at: {}".format(aprilTagFrameTime))
-            # print("Close April Tag replay")
-            aprilTagReplay1.close()
-            break
-        elif state == State.FindAprilTagPose and output.pose.time >= pairedFrameTime:
-            if aprilTagFramePose is None:
-                aprilTagFramePose = frame.cameraPose.pose.asMatrix()
-                print("April Tag pose at: {}\n{}".format(output.pose.time, aprilTagFramePose))
-            # print("Close April Tag replay")
-            aprilTagReplay2.close()
-            break
+state = None    
 
 def onRelocalizeExtendedOutput(output, frameSet):
     global args, relocalizedFrameTime, relocalizedFramePose, relocalizeReplay1, relocalizeReplay2, pairedFrameTime, state
-    #print(output.status)
     if not output.status == spectacularAI.TrackingStatus.TRACKING: return # not tracking yet
 
     for frame in frameSet:
         if not frame.image: continue
-        if not pairedFrameTime:
+        if state == State.FindRelocalizeTime:
             if not relocalizedFrameTime:
                 relocalizedFrameTime = output.pose.time
                 print("Tracking started with Relocalization at: {}".format(relocalizedFrameTime))
             # print("Close relocalize replay")
             relocalizeReplay1.close()
             break
-        elif state == State.FindRelocalizePose and output.pose.time >= pairedFrameTime:
+        elif state == State.FindRelocalizePose and output.pose.time >= aprilTagFrameTime:
             if relocalizedFramePose is None:
                 relocalizedFramePose = frame.cameraPose.pose.asMatrix()
-                print("Relocalized pose at: {}\n{}".format(output.pose.time, relocalizedFramePose))
+                print("Relocalized camera to world at: {}\n{}".format(output.pose.time, relocalizedFramePose))
             # print("Close relocalize replay")
             relocalizeReplay2.close()
             break
 
 def onAprilTagOutput(output):
+    global args, aprilTagFrameTime, aprilTagFramePose, aprilTagReplay1, state
+    
+    if aprilTagFrameTime is not None:
+        # print("Close April Tag replay")
+        aprilTagReplay1.close()
+        return
+
+    if not state == State.FindAprilTagTime: return # not looking for April Tag time
+    # if not output.status == spectacularAI.TrackingStatus.TRACKING: return # not tracking yet
     if not output.map.keyFrames: return # empty map
 
     # Find latest keyframe
     keyFrameId = max(output.map.keyFrames.keys())
     keyFrame = output.map.keyFrames[keyFrameId]
     frameSet = keyFrame.frameSet
-
     frame = frameSet.primaryFrame
+    frameTime = frame.cameraPose.pose.time
+    if not frameTime >= relocalizedFrameTime: return # not after relocalized time
+
+    # find a frame with a marker
     if frame is None or frame.image is None: return
     if frame.visualMarkers is None or frame.visualMarkers == []: return
     marker = frame.visualMarkers[0]
     if not marker.hasPose: 
         raise Exception("Found April Tag but it's not in the tags.json file")
+    
+    aprilTagFrameTime = frameTime
+    aprilTagFramePose = marker.pose.asMatrix()
+    print("April Tag to camera at: {}\n{}".format(frameTime, aprilTagFramePose))
 
 def replayAprilTags():
     global args, aprilTagReplay1, aprilTagReplay2, state
@@ -91,15 +81,8 @@ def replayAprilTags():
         "extendParameterSets" : ["april-tags"]
     }
 
-    replay = spectacularAI.Replay(args.dataFolder, onAprilTagOutput, configuration=configInternal)
-    replay.setExtendedOutputCallback(onAprilTagExtendedOutput)
-    
-    if state == State.FindAprilTagTime:
-        aprilTagReplay1 = replay
-    else:
-        aprilTagReplay2 = replay
-    
-    replay.runReplay()
+    aprilTagReplay1 = spectacularAI.Replay(args.dataFolder, onAprilTagOutput, configuration=configInternal)
+    aprilTagReplay1.runReplay()
 
 
 def replayRelocalize():
@@ -128,15 +111,6 @@ if __name__ == '__main__':
     p.add_argument("--preview", help="Show latest primary image as a preview", action="store_true")
     args =  p.parse_args()
 
-    state = State.FindAprilTagTime
-    print("Finding first April Tag frame time...")
-    aprilTagThread = threading.Thread(target=replayAprilTags)
-    aprilTagThread.start()
-    while aprilTagFrameTime is None and aprilTagThread.is_alive():
-        time.sleep(0.1)
-    if aprilTagFrameTime is None:
-        raise Exception("No valid frame found in April Tags replay")
-
     print("Finding first relocalized frame time...")
     state = State.FindRelocalizeTime
     relocalizeThread = threading.Thread(target=replayRelocalize)
@@ -145,19 +119,16 @@ if __name__ == '__main__':
         time.sleep(0.1)
     if relocalizedFrameTime is None:
         raise Exception("No valid frame found in Relocalize replay")
-    
-    pairedFrameTime = max(aprilTagFrameTime, relocalizedFrameTime)
-    print("Paired frame time: {}".format(pairedFrameTime))
 
-    print("Finding paired time in April Tags replay...")
-    state = State.FindAprilTagPose
+    state = State.FindAprilTagTime
+    print("Finding April Tag frame time (after Relocalized time)...")
     aprilTagThread = threading.Thread(target=replayAprilTags)
     aprilTagThread.start()
-    while aprilTagFramePose is None and aprilTagThread.is_alive():
+    while aprilTagFrameTime is None and aprilTagThread.is_alive():
         time.sleep(0.1)
-    if aprilTagFramePose is None:
-        raise Exception("Paired frame not found in April Tags replay")
-
+    if aprilTagFrameTime is None:
+        raise Exception("No valid frame found in April Tags replay")
+    
     print("Finding paired time in Relocalize replay...")
     state = State.FindRelocalizePose
     relocalizeThread = threading.Thread(target=replayRelocalize)

--- a/python/oak/relocalize_apriltags.py
+++ b/python/oak/relocalize_apriltags.py
@@ -9,8 +9,8 @@ args = None
 replay = None
 
 def onAprilTagExtendedOutput(output, frameSet):
-    global args, frameTime, aprilTagFramePose
-    if (aprilTagFramePose is not None): return # already found
+    global args, frameTime, relocalizedFramePose
+    if (relocalizedFramePose is not None): return # already found
     # print(output.status)
 
     if not output.status == spectacularAI.TrackingStatus.TRACKING: return # not tracking yet
@@ -18,9 +18,24 @@ def onAprilTagExtendedOutput(output, frameSet):
     for frame in frameSet:
         if not frame.image: continue
         aprilTagFramePose = frame.cameraPose.pose.asMatrix()
+        frameTime = output.pose.time
+        print("Tracking started with April Tag at: {}\n{}".format(frameTime, aprilTagFramePose))
+        replay.close() # stop replay
+        break
+
+def onRelocalizeExtendedOutput(output, frameSet):
+    global args, frameTime, aprilTagFramePose
+    if (aprilTagFramePose is not None): return # already found
+    print(output.status)
+
+    if not output.status == spectacularAI.TrackingStatus.TRACKING: return # not tracking yet
+
+    for frame in frameSet:
+        if not frame.image: continue
+        relocalizedFramePose = frame.cameraPose.pose.asMatrix()
         # print(dir(aprilTagFramePose))
         frameTime = output.pose.time
-        print("Found April Tag at: {}\n{}".format(frameTime, aprilTagFramePose))
+        print("Tracking started with Relocalization at: {}\n{}".format(frameTime, relocalizedFramePose))
         replay.close() # stop replay
         break
 
@@ -41,6 +56,9 @@ def onAprilTagOutput(output):
     if not marker.hasPose: 
         raise Exception("Found April Tag but it's not in the tags.json file")
     
+# def onRelocalizeOutput(output):
+    # nothing here
+
 def replayAprilTags():
     global args, replay
 
@@ -55,13 +73,33 @@ def replayAprilTags():
     replay.setExtendedOutputCallback(onAprilTagExtendedOutput)
     replay.runReplay()
 
+def replayRelocalize():
+    global args, replay
+
+    print("[Replay Relocalize] {}".format(args))
+
+    configInternal = {
+        "mapLoadPath": args.dataFolder + "/tags.json",
+        "extendParameterSets" : ["relocalization"]
+    }
+
+    replay = spectacularAI.Replay(args.dataFolder, configuration=configInternal)
+    replay.setExtendedOutputCallback(onRelocalizeExtendedOutput)
+    replay.runReplay()
+
 if __name__ == '__main__':
     p = argparse.ArgumentParser(__doc__)
     p.add_argument("dataFolder", nargs="?", help="Folder containing the recorded session and tags.json", default="data")
     p.add_argument("--preview", help="Show latest primary image as a preview", action="store_true")
     args =  p.parse_args()
 
-    replayAprilTags()
+    # replayAprilTags()
+    # if not frameTime:
+    #     raise Exception("No valid frame found in April Tags replay")
+
+    replayRelocalize()
+    if not frameTime:
+        raise Exception("No valid frame found in Relocalize replay")
 
     print("done")
     

--- a/python/oak/relocalize_apriltags.py
+++ b/python/oak/relocalize_apriltags.py
@@ -36,7 +36,7 @@ def onRelocalizeExtendedOutput(output, frameSet):
         elif state == State.FindRelocalizePose and output.pose.time >= aprilTagFrameTime:
             if relocalizedFramePose is None:
                 relocalizedFramePose = frame.cameraPose.pose.asMatrix()
-                print("Relocalized camera to world at: {}\n{}".format(output.pose.time, relocalizedFramePose))
+                print("Camera to relocalized world at: {}\n{}".format(output.pose.time, relocalizedFramePose))
             # print("Close relocalize replay")
             relocalizeReplay2.close()
             break

--- a/python/oak/relocalize_apriltags.py
+++ b/python/oak/relocalize_apriltags.py
@@ -1,47 +1,73 @@
 import argparse
 import spectacularAI
 import cv2
+import time
+import threading
+import os
+from enum import Enum
 
-frameTime = None
+class State(Enum):
+    FindAprilTagTime = 1
+    FindRelocalizeTime = 2
+    FindAprilTagPose = 3
+    FindRelocalizePose = 4
+
+pairedFrameTime = None
+aprilTagFrameTime = None
 aprilTagFramePose = None
+relocalizedFrameTime = None
 relocalizedFramePose = None
 args = None
-replay = None
+aprilTagReplay1 = None
+aprilTagReplay2 = None
+relocalizeReplay1 = None
+relocalizeReplay2 = None
+state = None
 
 def onAprilTagExtendedOutput(output, frameSet):
-    global args, frameTime, relocalizedFramePose
-    if (relocalizedFramePose is not None): return # already found
+    global args, aprilTagFrameTime, aprilTagFramePose, aprilTagReplay1, aprilTagReplay2, pairedFrameTime, state
     # print(output.status)
-
     if not output.status == spectacularAI.TrackingStatus.TRACKING: return # not tracking yet
 
     for frame in frameSet:
-        if not frame.image: continue
-        aprilTagFramePose = frame.cameraPose.pose.asMatrix()
-        frameTime = output.pose.time
-        print("Tracking started with April Tag at: {}\n{}".format(frameTime, aprilTagFramePose))
-        replay.close() # stop replay
-        break
+        if not pairedFrameTime:
+            if not aprilTagFrameTime:
+                aprilTagFrameTime = output.pose.time
+                print("Tracking started with April Tag at: {}".format(aprilTagFrameTime))
+            # print("Close April Tag replay")
+            aprilTagReplay1.close()
+            break
+        elif state == State.FindAprilTagPose and output.pose.time >= pairedFrameTime:
+            if aprilTagFramePose is None:
+                aprilTagFramePose = frame.cameraPose.pose.asMatrix()
+                print("April Tag pose at: {}\n{}".format(output.pose.time, aprilTagFramePose))
+            # print("Close April Tag replay")
+            aprilTagReplay2.close()
+            break
 
 def onRelocalizeExtendedOutput(output, frameSet):
-    global args, frameTime, aprilTagFramePose
-    if (aprilTagFramePose is not None): return # already found
-    print(output.status)
-
+    global args, relocalizedFrameTime, relocalizedFramePose, relocalizeReplay1, relocalizeReplay2, pairedFrameTime, state
+    #print(output.status)
     if not output.status == spectacularAI.TrackingStatus.TRACKING: return # not tracking yet
 
     for frame in frameSet:
         if not frame.image: continue
-        relocalizedFramePose = frame.cameraPose.pose.asMatrix()
-        # print(dir(aprilTagFramePose))
-        frameTime = output.pose.time
-        print("Tracking started with Relocalization at: {}\n{}".format(frameTime, relocalizedFramePose))
-        replay.close() # stop replay
-        break
+        if not pairedFrameTime:
+            if not relocalizedFrameTime:
+                relocalizedFrameTime = output.pose.time
+                print("Tracking started with Relocalization at: {}".format(relocalizedFrameTime))
+            # print("Close relocalize replay")
+            relocalizeReplay1.close()
+            break
+        elif state == State.FindRelocalizePose and output.pose.time >= pairedFrameTime:
+            if relocalizedFramePose is None:
+                relocalizedFramePose = frame.cameraPose.pose.asMatrix()
+                print("Relocalized pose at: {}\n{}".format(output.pose.time, relocalizedFramePose))
+            # print("Close relocalize replay")
+            relocalizeReplay2.close()
+            break
 
 def onAprilTagOutput(output):
-    global args, frameTime, aprilTagFramePose
-
     if not output.map.keyFrames: return # empty map
 
     # Find latest keyframe
@@ -55,14 +81,10 @@ def onAprilTagOutput(output):
     marker = frame.visualMarkers[0]
     if not marker.hasPose: 
         raise Exception("Found April Tag but it's not in the tags.json file")
-    
-# def onRelocalizeOutput(output):
-    # nothing here
 
 def replayAprilTags():
-    global args, replay
-
-    print("[Replay April Tags] {}".format(args))
+    global args, aprilTagReplay1, aprilTagReplay2, state
+    print("[Replay April Tags] {}".format(state))
 
     configInternal = {
         "aprilTagPath": args.dataFolder + "/tags.json",
@@ -71,21 +93,34 @@ def replayAprilTags():
 
     replay = spectacularAI.Replay(args.dataFolder, onAprilTagOutput, configuration=configInternal)
     replay.setExtendedOutputCallback(onAprilTagExtendedOutput)
+    
+    if state == State.FindAprilTagTime:
+        aprilTagReplay1 = replay
+    else:
+        aprilTagReplay2 = replay
+    
     replay.runReplay()
 
-def replayRelocalize():
-    global args, replay
 
-    print("[Replay Relocalize] {}".format(args))
+def replayRelocalize():
+    global args, relocalizeReplay1, relocalizeReplay2, state
+    # print("[Replay Relocalize] {}".format(args))
 
     configInternal = {
-        "mapLoadPath": args.dataFolder + "/tags.json",
+        "mapLoadPath": args.dataFolder + "/map.bin",
         "extendParameterSets" : ["relocalization"]
     }
 
     replay = spectacularAI.Replay(args.dataFolder, configuration=configInternal)
     replay.setExtendedOutputCallback(onRelocalizeExtendedOutput)
+ 
+    if state == State.FindRelocalizeTime:
+        relocalizeReplay1 = replay
+    else:
+        relocalizeReplay2 = replay
+ 
     replay.runReplay()
+
 
 if __name__ == '__main__':
     p = argparse.ArgumentParser(__doc__)
@@ -93,13 +128,46 @@ if __name__ == '__main__':
     p.add_argument("--preview", help="Show latest primary image as a preview", action="store_true")
     args =  p.parse_args()
 
-    # replayAprilTags()
-    # if not frameTime:
-    #     raise Exception("No valid frame found in April Tags replay")
+    state = State.FindAprilTagTime
+    print("Finding first April Tag frame time...")
+    aprilTagThread = threading.Thread(target=replayAprilTags)
+    aprilTagThread.start()
+    while aprilTagFrameTime is None and aprilTagThread.is_alive():
+        time.sleep(0.1)
+    if aprilTagFrameTime is None:
+        raise Exception("No valid frame found in April Tags replay")
 
-    replayRelocalize()
-    if not frameTime:
+    print("Finding first relocalized frame time...")
+    state = State.FindRelocalizeTime
+    relocalizeThread = threading.Thread(target=replayRelocalize)
+    relocalizeThread.start()
+    while relocalizedFrameTime is None and relocalizeThread.is_alive():
+        time.sleep(0.1)
+    if relocalizedFrameTime is None:
         raise Exception("No valid frame found in Relocalize replay")
+    
+    pairedFrameTime = max(aprilTagFrameTime, relocalizedFrameTime)
+    print("Paired frame time: {}".format(pairedFrameTime))
+
+    print("Finding paired time in April Tags replay...")
+    state = State.FindAprilTagPose
+    aprilTagThread = threading.Thread(target=replayAprilTags)
+    aprilTagThread.start()
+    while aprilTagFramePose is None and aprilTagThread.is_alive():
+        time.sleep(0.1)
+    if aprilTagFramePose is None:
+        raise Exception("Paired frame not found in April Tags replay")
+
+    print("Finding paired time in Relocalize replay...")
+    state = State.FindRelocalizePose
+    relocalizeThread = threading.Thread(target=replayRelocalize)
+    relocalizeThread.start()
+    while relocalizedFramePose is None and relocalizeThread.is_alive():
+        time.sleep(0.1)
+    if relocalizedFramePose is None:
+        raise Exception("Paired frame not found in Relocalize replay")
 
     print("done")
+    os._exit(0)
+
     

--- a/python/oak/relocalize_apriltags.py
+++ b/python/oak/relocalize_apriltags.py
@@ -1,0 +1,51 @@
+import argparse
+import spectacularAI
+import cv2
+
+frameTime = None
+aprilTagFramePose = None
+relocalizedFramePose = None
+
+def onOutput(output):
+    global frameTime
+    if output.frameSet is not None:
+        frameTime = output.frameSet.timestamp
+
+def onAprilTagMappingOutput(output, frameSet):
+    global frameTime, aprilTagFramePose
+    
+    for frame in frameSet:
+        if args.preview and frame.image:
+            cv2.imshow("Camera #{}".format(frame.index), cv2.cvtColor(frame.image.toArray(), cv2.COLOR_RGB2BGR))
+            cv2.waitKey(1)
+    print(output.asJson())
+
+    if not output.map.keyFrames: return # empty map
+
+    # Find latest keyframe
+    keyFrameId = max(output.map.keyFrames.keys())
+    keyFrame = output.map.keyFrames[keyFrameId]
+    frameSet = keyFrame.frameSet
+
+    frame = frameSet.primaryFrame
+    if frame is None or frame.image is None: return
+    if frame.visualMarkers is None or frame.visualMarkers == []: return
+    marker = frame.visualMarkers[0]
+    if not marker.hasPose: 
+        print("Warning: Found April Tag but it's not in the tags.json file")
+        return
+    
+    frameTime = output.frameSet.timestamp
+    aprilTagFramePose = frame.cameraPose.asMatrix()
+    print("Found April Tag at timestamp [{}] with pose: {}".format(frame.timestamp, aprilTagFramePose))
+
+if __name__ == '__main__':
+    p = argparse.ArgumentParser(__doc__)
+    p.add_argument("dataFolder", help="Folder containing the recorded session and tags.json", default="data")
+    p.add_argument("--preview", help="Show latest primary image as a preview", action="store_true")
+    args =  p.parse_args()
+
+    replay = spectacularAI.Replay(args.dataFolder)
+
+    replay.setExtendedOutputCallback(onAprilTagMappingOutput)
+    replay.runReplay()


### PR DESCRIPTION
Adds python/oak/relocalize-apriltags-example.py, an example of how to align a saved SLAM map with a recorded April Tag session. For complete instructions on how to use this tool to align a digital twin in Unity with your SLAM map, see the [README.md in the SpectacularAI/unity-example PR #2](https://github.com/SpectacularAI/unity-wrapper/blob/aade6a3faa54024068d73bd4676b02bf47fa9ddf/unity-examples/Assets/SpectacularAI/Examples/AprilTag/README.md).