### PR TITLE
Fix glDrawPixels error in mapping_ar.py

### DIFF
--- a/python/oak/mapping_ar.py
+++ b/python/oak/mapping_ar.py
@@ -106,7 +106,11 @@ def handleVioOutput(state, cameraPose, t, img, width, height, colorFormat):
             return
 
     glPixelZoom(state.scale, state.scale)
-    glDrawPixels(width, height, GL_LUMINANCE if colorFormat == spectacularAI.ColorFormat.GRAY else GL_RGB, GL_UNSIGNED_BYTE, img.data)
+    glDrawPixels(
+        width,
+        height,
+        GL_LUMINANCE if colorFormat == spectacularAI.ColorFormat.GRAY else GL_RGB, GL_UNSIGNED_BYTE,
+        np.frombuffer(img. data, dtype=np.uint8))
 
     updateRenderer(state, cameraPose, t)
 


### PR DESCRIPTION
With Python 3.8 `mapping_ar.py` window is black and glDrawPixels gives the following with
`TypeError: ("<class 'memoryview'> type does not support Buffer Protocol", <OpenGL.GL.images.ImageInputConverter object at ...>)`
